### PR TITLE
Enable custom regex tokenizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ It also breaks up accented words, using the accented character as the separator.
 Setting `alternativeTokenizer` to `true` uses a more generous regular expression
 that respects these characters.
 
+If you wish to use your own regular expression, you can set `alternativeTokenizer` to regular expression eg. `/\b[^s]+\b/` to tokenize as you like.
+
 ```js
 keyword.extract('Lörem Ipsüm Lörem Ipsüm.', {alternativeTokenizer: true})
 ```

--- a/index.js
+++ b/index.js
@@ -69,8 +69,11 @@ exports.extract = function(text, options){
   _.each(options.ngrams, function(ngram){
     var keywordsForNgram;
     var tf = new Tf();
-    if (options.alternativeTokenizer) {
+    if (options.alternativeTokenizer === true) {
       natural.NGrams.setTokenizer(new natural.RegexpTokenizer({pattern: /\b[^\s]+\b/g, gaps: false}));
+    }
+    else if (options.alternativeTokenizer) {
+      natural.NGrams.setTokenizer(new natural.RegexpTokenizer({pattern: options.alternativeTokenizer, gaps: false}));
     }
     var tokenized = _.map(natural.NGrams.ngrams(text, ngram), function(ngram){
       if (options.stem){

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ exports.extract = function(text, options){
       natural.NGrams.setTokenizer(new natural.RegexpTokenizer({pattern: /\b[^\s]+\b/g, gaps: false}));
     }
     else if (options.alternativeTokenizer) {
-      natural.NGrams.setTokenizer(new natural.RegexpTokenizer({pattern: options.alternativeTokenizer, gaps: false}));
+      natural.NGrams.setTokenizer(new natural.RegexpTokenizer({pattern: new RegExp(options.alternativeTokenizer.source, "g"), gaps: false}));
     }
     var tokenized = _.map(natural.NGrams.ngrams(text, ngram), function(ngram){
       if (options.stem){

--- a/test/extract.js
+++ b/test/extract.js
@@ -123,7 +123,7 @@ test('accented characters', function (t){
 
 test('accented characters w/ custom tokenizer', function(t){
   var text = 'Hallo Welt! Das ist ein Text über ganz viele Umlaute wie äöüÄÖÜß. Lörem Ipsüm Lörem Ipsüm. Lämmin kesä. Lämmin kesä.';
-  var options = {ngrams: 1, alternativeTokenizer: /[^(\s]([^\s]*[^?!:;,\.)\s])+|[\wå-öÅ-Ö]/g};
+  var options = {ngrams: 1, alternativeTokenizer: /[^(\s]([^\s]*[^?!:;,\.)\s])+|[\wå-öÅ-Ö]/};
   t.deepEqual(k.extract(text, options), ['lämmin', 'ipsüm', 'lörem', 'kesä']);
   t.end();
 });

--- a/test/extract.js
+++ b/test/extract.js
@@ -121,9 +121,16 @@ test('accented characters', function (t){
   t.end();
 });
 
+test('accented characters w/ custom tokenizer', function(t){
+  var text = 'Hallo Welt! Das ist ein Text über ganz viele Umlaute wie äöüÄÖÜß. Lörem Ipsüm Lörem Ipsüm. Lämmin kesä. Lämmin kesä.';
+  var options = {ngrams: 1, alternativeTokenizer: /[^(\s]([^\s]*[^?!:;,\.)\s])+|[\wå-öÅ-Ö]/g};
+  t.deepEqual(k.extract(text, options), ['lämmin', 'ipsüm', 'lörem', 'kesä']);
+  t.end();
+});
+
 test('basic Spanish', function (t){
   var text = 'No nos etiquetéis solo porque nos traiga sin cuidado qué nacionalidad nos adjudica el documento de identidad. Ni porque cuando suena un himno nacional, cualquiera que este sea, la mano no se nos dispare automáticamente hacia el pecho en alarde de amor patrio. Ni porque el flamear de las enseñas, que a vosotros tanto os conmueve, a nosotros nos deje indiferentes.';
   var options = {lang: 'es', min: 1, limit: 2, ngrams: [1,2]};
   t.deepEqual(k.extract(text, options), ['os conmueve', 'amor patrio']);
   t.end();
-})
+});


### PR DESCRIPTION
Solves the problem with words ending with an accented character. Eg. "kesä" was tokenized as "kes" with {alternativeTokenizer: true}.

Also gives the developers possibility to tokenize exactly the way they want.
